### PR TITLE
menus: Mark menus as extern where applicable

### DIFF
--- a/include/menus/cheats.h
+++ b/include/menus/cheats.h
@@ -2,9 +2,9 @@
 
 #include "menu.h"
 
-Menu CheatsMenu;
-Menu CheatsItemsMenu;
-Menu CheatsKeysMenu;
+extern Menu CheatsMenu;
+extern Menu CheatsItemsMenu;
+extern Menu CheatsKeysMenu;
 
 void Cheats_Health(void);
 void Cheats_Magic(void);

--- a/include/menus/equips.h
+++ b/include/menus/equips.h
@@ -2,4 +2,4 @@
 
 #include "menu.h"
 
-Menu EquipsMenu;
+extern Menu EquipsMenu;

--- a/include/menus/file.h
+++ b/include/menus/file.h
@@ -2,4 +2,4 @@
 
 #include "menu.h"
 
-Menu FileMenu;
+extern Menu FileMenu;

--- a/include/menus/inventory.h
+++ b/include/menus/inventory.h
@@ -3,16 +3,14 @@
 #include "menu.h"
 #include "z3D/z3D.h"
 
-Menu InventoryMenu;
-ToggleMenu InventoryItemsMenu;
-ToggleMenu InventoryBottlesMenu;
-ToggleMenu InventoryChildTradeMenu;
-ToggleMenu InventoryAdultTradeMenu;
-ToggleMenu InventoryRightGearMenu;
-ToggleMenu InventoryLeftGearMenu;
-AmountMenu InventoryAmountsMenu;
-
-u32 SelectedBottle;
+extern Menu InventoryMenu;
+extern ToggleMenu InventoryItemsMenu;
+extern ToggleMenu InventoryBottlesMenu;
+extern ToggleMenu InventoryChildTradeMenu;
+extern ToggleMenu InventoryAdultTradeMenu;
+extern ToggleMenu InventoryRightGearMenu;
+extern ToggleMenu InventoryLeftGearMenu;
+extern AmountMenu InventoryAmountsMenu;
 
 void Inventory_ItemsMenuFunc(void);
 void Inventory_ItemsToggle(s32);

--- a/include/menus/scene.h
+++ b/include/menus/scene.h
@@ -2,4 +2,4 @@
 
 #include "menu.h"
 
-Menu SceneMenu;
+extern Menu SceneMenu;

--- a/src/inventory.c
+++ b/src/inventory.c
@@ -4,6 +4,8 @@
 #include "z3D/z3D.h"
 #include <stdio.h>
 
+static u32 SelectedBottle;
+
 Menu InventoryMenu = {
     "Cheats",
     .nbItems = 3,


### PR DESCRIPTION
Prevents the compiler from assuming the identifier is a completely new one when included into other files. This prevents any potential linkage issues from occurring related to these variables, considering their definitions lie within `.c` files.

While we're at it, we can relocate the selected bottle variable into inventory.c, which is the only place that it's used.