### PR TITLE
patch.py: Use objdump from devkitPro

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -1,10 +1,10 @@
-import sys
-import subprocess
+import os
 import struct
-
+import subprocess
+import sys
 
 elf = sys.argv[1]
-result = subprocess.run([r'/opt/arm-linux-musleabi-cross/bin/arm-linux-musleabi-objdump', '--section-headers', elf], stdout=subprocess.PIPE)
+result = subprocess.run([os.environ["DEVKITARM"] + r'/bin/arm-none-eabi-objdump', '--section-headers', elf], stdout=subprocess.PIPE)
 lines = str(result.stdout).split('\\n')
 sectionsInfo = [line.split()[1:6] for line in lines if line.split() and line.split()[0].isdigit()]
 sections = ((int(sec[2],16), int(sec[4],16), int(sec[1],16)) for sec in sectionsInfo if int(sec[2],16) != 0)


### PR DESCRIPTION
Allows the patching script to work fully with devkitPro and doesn't rely on musl.

With this, it's possible to fully generate the IPS file on a Windows machine.