### PR TITLE
menu: Automatically scroll down the menu if up/down/left/right is held

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -39,11 +39,27 @@ u32 waitInputWithTimeout(u32 msec)
     u32 key = 0;
     u32 n = 0;
 
-    //Wait for no keys to be pressed
-    while(HID_PAD && (msec == 0 || n < msec))
+    const bool isDPadPressed = (HID_PAD & BUTTON_UP) != 0 ||
+                               (HID_PAD & BUTTON_DOWN) != 0 ||
+                               (HID_PAD & BUTTON_LEFT) != 0 ||
+                               (HID_PAD & BUTTON_RIGHT) != 0;
+
+    // We special the D-Pad as we want to automatically scroll the cursor or
+    // allow amount editing at a reasonable pace as long as it's held down.
+    if (isDPadPressed)
     {
-        svcSleepThread(1 * 1000 * 1000LL);
-        n++;
+        // By default wait 75 milliseconds before moving the cursor so that
+        // we don't scroll the menu too fast.
+        svcSleepThread(75 * 1000 * 1000LL);
+    }
+    else
+    {
+        // Wait for no keys to be pressed in the event that up and down are not pressed.
+        while (HID_PAD && (msec == 0 || n <= msec))
+        {
+            svcSleepThread(1 * 1000 * 1000LL);
+            n++;
+        }
     }
 
     if(msec != 0 && n >= msec)


### PR DESCRIPTION
Allows a user of the mod to scroll up and down menus which is much more convenient than having to continually press up or down repeatedly to reach the desired menu selection.

We currently cap the speed at 75 ms as this allows the menu to scroll at a reasonable speed with a delay long enough that the user won't accidentally skip over what they were looking for.