### PR TITLE
menus: Remove test function

### DIFF
--- a/include/menus.h
+++ b/include/menus.h
@@ -31,11 +31,3 @@
 #include "menu.h"
 
 extern Menu gz3DMenu;
-
-void gz3DMenu_Test(void);
-// void RosalinaMenu_TakeScreenshot(void);
-// void RosalinaMenu_ShowCredits(void);
-// void RosalinaMenu_ProcessList(void);
-// void RosalinaMenu_PowerOff(void);
-// void RosalinaMenu_Reboot(void);
-// void RosalinaMenu_Cheats(void);

--- a/src/menus.c
+++ b/src/menus.c
@@ -45,7 +45,6 @@ Menu gz3DMenu = {
     "Practice Menu",
     .nbItems = 8,
     {
-        // { "Test method placeholder, sets rupees to 50", METHOD, .method = &gz3DMenu_Test },
         { "Warps", MENU, .menu = &WarpsMenu },
         { "Scene", MENU, .menu = &SceneMenu },
         { "Cheats", MENU, .menu = &CheatsMenu },
@@ -57,8 +56,3 @@ Menu gz3DMenu = {
         { "Commands", METHOD, .method = Commands_ShowCommands },
     }
 };
-
-void gz3DMenu_Test(void){
-    gSaveContext.rupees = 50;
-    return;
-}


### PR DESCRIPTION
The menu is already in a functional state, so there's no need to keep this around anymore.